### PR TITLE
Feature/gme downloader

### DIFF
--- a/gme_data_dictionary.json
+++ b/gme_data_dictionary.json
@@ -1,0 +1,82 @@
+{
+    "categories": [
+        {
+            "name": "MGP",
+            "types": [
+                "StimeFabbisogno",
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Quantita",
+                "Liquidita",
+                "Transiti",
+                "Fabbisogno",
+                "OfferteIntegrativeGrtn",
+                "Prezzi",
+                "MarketCoupling"
+            ]
+        },
+        {
+            "name": "MI1",
+            "types": [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name": "MI2",
+            "types": [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name": "MI3",
+            "types": [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name": "MI4",
+            "types": [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name": "MI5",
+            "types": [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name": "MI6",
+            "types": [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name": "MI7",
+            "types": [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        }
+    ]
+}

--- a/gme_downloader.py
+++ b/gme_downloader.py
@@ -1,92 +1,16 @@
 from datetime import date
+from pathlib import Path
+import json
 import requests
 
+DICTIONARY_PATH = Path("gme_data_dictionary.json")
 
 class GMEDownloader:
     '''
     Downloads all kind of data from https://www.mercatoelettrico.org/
     '''
 
-    DICTIONARY = {"categories": [
-        {
-            "name": "MGP",
-            "types": [
-                "StimeFabbisogno",
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Quantita",
-                "Liquidita",
-                "Transiti",
-                "Fabbisogno",
-                "OfferteIntegrativeGrtn",
-                "Prezzi",
-                "MarketCoupling"
-            ]
-        },
-        {
-            "name": "MI1",
-            "types": [
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Prezzi",
-                "Quantita"
-            ]
-        },
-        {
-            "name": "MI2",
-            "types": [
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Prezzi",
-                "Quantita"
-            ]
-        },
-        {
-            "name": "MI3",
-            "types": [
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Prezzi",
-                "Quantita"
-            ]
-        },
-        {
-            "name": "MI4",
-            "types": [
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Prezzi",
-                "Quantita"
-            ]
-        },
-        {
-            "name": "MI5",
-            "types": [
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Prezzi",
-                "Quantita"
-            ]
-        },
-        {
-            "name": "MI6",
-            "types": [
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Prezzi",
-                "Quantita"
-            ]
-        },
-        {
-            "name": "MI7",
-            "types": [
-                "LimitiTransito",
-                "PrezziConvenzionali",
-                "Prezzi",
-                "Quantita"
-            ]
-        }
-    ]}
+    DICTIONARY = json.load(DICTIONARY_PATH.open("r"))
 
     def get_everything_date(self, day: date, ignore_errors: bool = False):
         '''

--- a/gme_downloader.py
+++ b/gme_downloader.py
@@ -183,6 +183,6 @@ class GMEDownloader:
         raise ValueError("Required value could not be found ({}, {}, {})".format(
             category, req_type, day))
 
-
-downloader = GMEDownloader()
-print(downloader.get_everything_date(date(2020, 4, 11), ignore_errors=False))
+if __name__ == '__main__':
+    downloader = GMEDownloader()
+    print(downloader.get_everything_date(date(2020, 4, 11), ignore_errors=False))

--- a/gme_downloader.py
+++ b/gme_downloader.py
@@ -1,0 +1,31 @@
+import requests
+from datetime import date
+
+COOKIE_GMEITALIANO = "73121C41475ED92C082815C756EF486AEDB084515F184617CD3E736CBA2E1633BB5ED56855453D5599AA5CCFEC57CD70680B6541DA0654E94B6B5334DB04380FCBD154AA7B815603F909F96E2756D9E299D4F4F1AAB3B92694C27D3EF310D8D1AE0ADD7AD08C66B54A426D22068C1688CAB6B03B1483F67B2FA69202AEF21D22A7600AA867D1E101CD17A015061BA2A56250EF00DEF77F871FC486DA3EE2AB84"
+
+class GMEDownloader:
+    '''
+    Downloads all kind of data from https://www.mercatoelettrico.org/
+    '''
+
+    def MGP_informazioni_preliminari(self, category : str, day : date):
+        '''
+        Downloads data from MGP/informazioni preliminari/category
+
+        Parameters:
+            category : str
+                Must be one of the following: "StimeFabbisogno", "LimitiTransito", "PrezziConvenzionali"
+            date : date
+                Any date between 2009 circa and today, depends on the type of data.
+        '''
+        session = requests.Session()
+        jar = requests.cookies.RequestsCookieJar()
+        jar.set("GmeItaliano",COOKIE_GMEITALIANO)
+        session.cookies = jar
+
+        formatted_date = day.strftime("%Y%m%d")
+        r = session.get('https://www.mercatoelettrico.org/It/WebServerDataStore/MGP_{}/{}MGP{}.xml'.format(category, formatted_date, category))
+        print(r.text)
+
+downloader = GMEDownloader()
+downloader.MGP_informazioni_preliminari("StimeFabbisogno", date.today())

--- a/gme_downloader.py
+++ b/gme_downloader.py
@@ -1,5 +1,5 @@
-import requests
 from datetime import date
+import requests
 
 
 class GMEDownloader:
@@ -7,10 +7,10 @@ class GMEDownloader:
     Downloads all kind of data from https://www.mercatoelettrico.org/
     '''
 
-    DICTIONARY = { "categories" :[
+    DICTIONARY = {"categories": [
         {
-            "name" : "MGP",
-            "types" : [
+            "name": "MGP",
+            "types": [
                 "StimeFabbisogno",
                 "LimitiTransito",
                 "PrezziConvenzionali",
@@ -24,8 +24,8 @@ class GMEDownloader:
             ]
         },
         {
-            "name" : "MI1",
-            "types" : [
+            "name": "MI1",
+            "types": [
                 "LimitiTransito",
                 "PrezziConvenzionali",
                 "Prezzi",
@@ -33,8 +33,8 @@ class GMEDownloader:
             ]
         },
         {
-            "name" : "MI2",
-            "types" : [
+            "name": "MI2",
+            "types": [
                 "LimitiTransito",
                 "PrezziConvenzionali",
                 "Prezzi",
@@ -42,8 +42,8 @@ class GMEDownloader:
             ]
         },
         {
-            "name" : "MI3",
-            "types" : [
+            "name": "MI3",
+            "types": [
                 "LimitiTransito",
                 "PrezziConvenzionali",
                 "Prezzi",
@@ -51,8 +51,8 @@ class GMEDownloader:
             ]
         },
         {
-            "name" : "MI4",
-            "types" : [
+            "name": "MI4",
+            "types": [
                 "LimitiTransito",
                 "PrezziConvenzionali",
                 "Prezzi",
@@ -60,8 +60,8 @@ class GMEDownloader:
             ]
         },
         {
-            "name" : "MI5",
-            "types" : [
+            "name": "MI5",
+            "types": [
                 "LimitiTransito",
                 "PrezziConvenzionali",
                 "Prezzi",
@@ -69,8 +69,8 @@ class GMEDownloader:
             ]
         },
         {
-            "name" : "MI6",
-            "types" : [
+            "name": "MI6",
+            "types": [
                 "LimitiTransito",
                 "PrezziConvenzionali",
                 "Prezzi",
@@ -78,8 +78,8 @@ class GMEDownloader:
             ]
         },
         {
-            "name" : "MI7",
-            "types" : [
+            "name": "MI7",
+            "types": [
                 "LimitiTransito",
                 "PrezziConvenzionali",
                 "Prezzi",
@@ -88,7 +88,7 @@ class GMEDownloader:
         }
     ]}
 
-    def get_everything_date(self, day : date, ignore_errors : bool = False):
+    def get_everything_date(self, day: date, ignore_errors: bool = False):
         '''
         Downloads everything from every known GME source for a given day.
 
@@ -127,9 +127,9 @@ class GMEDownloader:
         Returns:
             Retrieved XML file as a string.
         '''
-        return self.get_data("MGP",req_type, day)
+        return self.get_data("MGP", req_type, day)
 
-    def get_MI(self, number : int, req_type : str, day : date):
+    def get_MI(self, number: int, req_type: str, day: date):
         '''
         Downloads data from MI-number (1 to 7)
 
@@ -180,7 +180,9 @@ class GMEDownloader:
         response = session.post(url, data=post_data)
         if(response.status_code == 200):
             return response.text
-        raise ValueError("Required value could not be found ({}, {}, {})".format(category, req_type, day))
+        raise ValueError("Required value could not be found ({}, {}, {})".format(
+            category, req_type, day))
+
 
 downloader = GMEDownloader()
-print(downloader.get_everything_day(date(2020,4,11), ignore_errors=False))
+print(downloader.get_everything_date(date(2020, 4, 11), ignore_errors=False))

--- a/gme_downloader.py
+++ b/gme_downloader.py
@@ -7,36 +7,131 @@ class GMEDownloader:
     Downloads all kind of data from https://www.mercatoelettrico.org/
     '''
 
-    def MGP_informazioni_preliminari(self, req_type: str, day: date):
+    DICTIONARY = { "categories" :[
+        {
+            "name" : "MGP",
+            "types" : [
+                "StimeFabbisogno",
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Quantita",
+                "Liquidita",
+                "Transiti",
+                "Fabbisogno",
+                "OfferteIntegrativeGrtn"
+                "Prezzi",
+                "MarketCoupling"
+            ]
+        },
+        {
+            "name" : "MI1",
+            "types" : [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name" : "MI2",
+            "types" : [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name" : "MI3",
+            "types" : [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name" : "MI4",
+            "types" : [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name" : "MI5",
+            "types" : [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name" : "MI6",
+            "types" : [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        },
+        {
+            "name" : "MI7",
+            "types" : [
+                "LimitiTransito",
+                "PrezziConvenzionali",
+                "Prezzi",
+                "Quantita"
+            ]
+        }
+    ]}
+
+    def get_MGP(self, req_type: str, day: date):
         '''
-        Downloads data from MGP/informazioni preliminari/category
+        Downloads data from MGP
 
         Parameters:
-            type : str
-                Must be one of the following: "StimeFabbisogno", "LimitiTransito", "PrezziConvenzionali"
+            req_type : str
+                Could be one of the following: "StimeFabbisogno", "LimitiTransito", "PrezziConvenzionali", "Quantita", "Liquidita", "Transiti", "Fabbisogno", "OfferteIntegrativeGrtn"
+                "Prezzi", "MarketCoupling"
             date : date
                 Any date between 2009 circa and today, depends on the type of data.
+        Raises:
+            ValueError when required data could not be retrieved (wrong date or req_type)
         '''
-        return self.__get_data("MGP",req_type, day)
+        return self.get_data("MGP",req_type, day)
 
-    def __get_data(self, category: str, req_type: str, day: date):
+    def get_MI(self, number : int, req_type : str, day : date):
+        '''
+        Downloads data from MI-number (1 to 7)
+
+        Parameters:
+            req_type : str
+                Must be one of the following: "LimitiTransito", "PrezziConvenzionali", "Prezzi", "Quantita"
+            date : date
+                Any date between 2009 circa and today, depends on the type of data.
+        Raises:
+            ValueError when required data could not be retrieved (wrong date or req_type)
+        '''
+        return self.get_data("MI{}".format(number), req_type, day)
+
+    def get_data(self, category: str, req_type: str, day: date):
         '''
         Prepares request with necessary cookies and post data to bypass required conditions.
 
         Parameters:
             category : str
                 Could be "MGP" or "MI1" to "MI7".
-            type : str
+            req_type : str
                 Depends on the category, could be "Prezzi" or "Quantita" or "Fabbisogno" and more.
             day : date
                 Any date between 2009 circa and today, depends on category and date.
         Raises:
-            ValueError when required data could not be retrieved (wrong date, category or type)
+            ValueError when required data could not be retrieved (wrong date, category or req_type)
         '''
         session = requests.Session()
-        jar = requests.cookies.RequestsCookieJar()
-        jar.set("ASP.NET_SessionId", "sqv5qb5aeydcc1sjjuzlshlx")
-        session.cookies = jar
         post_data = {
             '__VIEWSTATE': '/wEPDwULLTIwNTEyNDQzNzQPZBYCZg9kFgICAw9kFgJmD2QWBAIMD2QWAmYPZBYCZg9kFgICCQ8PZBYCHgpvbmtleXByZXNzBRxyZXR1cm4gaW52aWFQV0QodGhpcyxldmVudCk7ZAIVD2QWAgIBDw8WAh4NT25DbGllbnRDbGljawUmamF2YXNjcmlwdDp3aW5kb3cub3BlbignP3N0YW1wYT10cnVlJylkZBgBBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WBQUMY3RsMDAkSW1hZ2UxBRJjdGwwMCRJbWFnZUJ1dHRvbjEFIGN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkc3RhbXBhBSRjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJENCQWNjZXR0bzEFJGN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkQ0JBY2NldHRvMvV5e94ExnpHUcybAr1bPdOOHxYDHpQG7fgAyUlbfpUy',
             # '__VIEWSTATEGENERATOR' : 'BD5243C0',
@@ -57,3 +152,6 @@ class GMEDownloader:
             return response.text
         raise ValueError("Required value could not be found ({}, {}, {})".format(category, req_type, day))
 
+
+downloader = GMEDownloader()
+print(downloader.get_MGP("StimeFabbisogno", date(2020,4,17)))

--- a/gme_downloader.py
+++ b/gme_downloader.py
@@ -18,7 +18,7 @@ class GMEDownloader:
                 "Liquidita",
                 "Transiti",
                 "Fabbisogno",
-                "OfferteIntegrativeGrtn"
+                "OfferteIntegrativeGrtn",
                 "Prezzi",
                 "MarketCoupling"
             ]
@@ -88,6 +88,30 @@ class GMEDownloader:
         }
     ]}
 
+    def get_everything_date(self, day : date, ignore_errors : bool = False):
+        '''
+        Downloads everything from every known GME source for a given day.
+
+        Parameters:
+            day : date
+                Any date between 2009 circa and today, depends on the type of data.
+            ignore_errors : bool
+                If the method should stop on errors or just go on to download the rest.
+        Raises:
+            ValueError when required data could not be retrieved (wrong date, req_type or even missing data).
+        Returns:
+            A list of strings containing downloaded XML files.
+        '''
+        data = list()
+        for category in self.DICTIONARY['categories']:
+            for req_type in category['types']:
+                try:
+                    data.append(self.get_data(category['name'], req_type, day))
+                except ValueError as error:
+                    if ignore_errors == False:
+                        raise ValueError(error)
+        return data
+
     def get_MGP(self, req_type: str, day: date):
         '''
         Downloads data from MGP
@@ -99,7 +123,9 @@ class GMEDownloader:
             date : date
                 Any date between 2009 circa and today, depends on the type of data.
         Raises:
-            ValueError when required data could not be retrieved (wrong date or req_type)
+            ValueError when required data could not be retrieved (wrong date or req_type).
+        Returns:
+            Retrieved XML file as a string.
         '''
         return self.get_data("MGP",req_type, day)
 
@@ -113,7 +139,9 @@ class GMEDownloader:
             date : date
                 Any date between 2009 circa and today, depends on the type of data.
         Raises:
-            ValueError when required data could not be retrieved (wrong date or req_type)
+            ValueError when required data could not be retrieved (wrong date or req_type).
+        Returns:
+            Retrieved XML file as a string.
         '''
         return self.get_data("MI{}".format(number), req_type, day)
 
@@ -129,7 +157,9 @@ class GMEDownloader:
             day : date
                 Any date between 2009 circa and today, depends on category and date.
         Raises:
-            ValueError when required data could not be retrieved (wrong date, category or req_type)
+            ValueError when required data could not be retrieved (wrong date, category or req_type).
+        Returns:
+            Retrieved XML file as a string.
         '''
         session = requests.Session()
         post_data = {
@@ -152,6 +182,5 @@ class GMEDownloader:
             return response.text
         raise ValueError("Required value could not be found ({}, {}, {})".format(category, req_type, day))
 
-
 downloader = GMEDownloader()
-print(downloader.get_MGP("StimeFabbisogno", date(2020,4,17)))
+print(downloader.get_everything_day(date(2020,4,11), ignore_errors=False))


### PR DESCRIPTION
## Premise
We have to download data from GME right? There are three ways:
1) Hand pick dates to download and do it by hand for every category on the downloads page.
2) Require access to FTP by ending an irl mail to Rome and get credentials back by irl mail.
3) Somehow hack the web pages to let them think you're a human pressing buttons.
Here we are having a look at how I implemented 3.

## Changes

Created `GMEDownloader` class, the main method is `get_data` that is responsible for everything else.
The class doesn't have attributes or anything so it could actually be just a module, but I preferred to keep it organized.

### get_data method

Uses python requests library to create a session (could have avoided using a session because there are no cookies actually, but might be useful for future edits (?)) and then creates an HTTP POST request with fake form data saying "yes I accept" twice so that their system is tricked to think the terms of use acceptance form has been filled correctly.
`_VIEWSTATE` and `__EVENTVALIDATION` are required for the trick to work, the value of those two keys has been found in deep research in the network page of my browser and they were kinda the same so I hope they'll be ok on other computers too.

`DICTIONARY` contains all possible data this class is able to extract from the website.

If data hasn't been found or there has been an error (status code != 200) it raises a ValueError (stole it from alpha vantage).

### Warning

This class is not meant to create files, I'd like to move that kind of functions to another class in common with YahooFinance downloader and AphaVantage downloader

That's it.
Have fun.